### PR TITLE
Change the way to run BM_*_BACKUP_COMMAND

### DIFF
--- a/backup-manager.conf.tpl
+++ b/backup-manager.conf.tpl
@@ -477,6 +477,11 @@ export BM_UPLOAD_RSYNC_DUMPSYMLINKS="false"
 # it as a mask, so will exclude any file/folder corresponding to it
 export BM_UPLOAD_RSYNC_BLACKLIST=""
 
+# Extra options to append to rsync
+# (take care to what you do; this will be silently added to the
+# command line.)
+export BM_UPLOAD_RSYNC_EXTRA_OPTIONS=""
+
 ##############################################################
 # Section "BURNING" 
 # - Automatic CDR/CDRW/DVDR burning

--- a/lib/actions.sh
+++ b/lib/actions.sh
@@ -108,9 +108,8 @@ function clean_repositories()
     clean_directory $BM_REPOSITORY_ROOT
 }
 
-
 # This will run the pre-command given.
-# If this command prints on STDOUT "false", 
+# If this command exit with non-zero status,
 # backup-manager will stop here.
 function exec_pre_command()
 {
@@ -118,17 +117,13 @@ function exec_pre_command()
 
     if [[ ! -z "$BM_PRE_BACKUP_COMMAND" ]]; then
         info "Running pre-command: \$BM_PRE_BACKUP_COMMAND."
-        RET=`$BM_PRE_BACKUP_COMMAND >/dev/null 2>&1` || RET="false" 
-        case "$RET" in
-            "false")
-                warning "Pre-command failed. Stopping the process."
-                _exit 15 "PRE_COMMAND"
-            ;;
-
-            *)
-                info "Pre-command returned: \"\$RET\" (success)."
-            ;;
-        esac
+        $BM_PRE_BACKUP_COMMAND
+        if [ $? -eq 0 ]; then
+            info "Pre-command succeeded."
+        else
+            warning "Pre-command failed. Stopping the process."
+            _exit 15 "PRE_COMMAND"
+        fi
     fi
 
 }
@@ -139,17 +134,13 @@ function exec_post_command()
 
     if [[ ! -z "$BM_POST_BACKUP_COMMAND" ]]; then
         info "Running post-command: \$BM_POST_BACKUP_COMMAND"
-        RET=`$BM_POST_BACKUP_COMMAND >/dev/null 2>&1` || RET="false"
-        case "$RET" in
-            "false")
-                warning "Post-command failed."
-                _exit 16 "POST_COMMAND"
-            ;;
-
-            *)
-                info "Post-command returned: \"\$RET\" (success)."
-            ;;
-        esac
+        $BM_POST_BACKUP_COMMAND
+        if [ $? -eq 0 ]; then
+            info "Post-command succeeded."
+        else
+            warning "Post-command failed."
+            _exit 15 "POST_COMMAND"
+        fi
     fi
 }
 

--- a/lib/upload-methods.sh
+++ b/lib/upload-methods.sh
@@ -234,6 +234,10 @@ function bm_upload_rsync_common()
         rsync_options="${rsync_options} --exclude=\"$BM_UPLOAD_RSYNC_BLACKLIST\""
     fi
 
+    if [[ ! -z $BM_UPLOAD_RSYNC_EXTRA_OPTIONS ]]; then
+        rsync_options="${rsync_options} $BM_UPLOAD_RSYNC_EXTRA_OPTIONS"
+    fi
+
     for directory in $BM_UPLOAD_RSYNC_DIRECTORIES
     do
         if [[ -n "$bm_upload_hosts" ]]; then


### PR DESCRIPTION
"Directly" means that configured command runs without forced
redirection, allowing administrator more flexibility.
For example, if backup-manager is being run from cron, administrator
can setup BM_POST_BACKUP_COMMAND like this:
  do-some-checking-stuff >/dev/null
In this case, if there is errors on stderr, cron will mail it.
Anyway, it allows much more things like logging.

The point is to allow admin to manipulate streams the way he/she wants.
If pre-command exists with non-zero status backup will not proceed.

This change is not bc in the matter of "false" output.