### PR TITLE
Save MySQL DBs separately

### DIFF
--- a/backup-manager.conf.tpl
+++ b/backup-manager.conf.tpl
@@ -225,6 +225,12 @@ export BM_MYSQL_FILETYPE="bzip2"
 # command line.)
 export BM_MYSQL_EXTRA_OPTIONS=""
 
+# Make separate backups of each database?
+export BM_MYSQL_SEPARATELY="true"
+
+# Specify DBs to exclude here (separated by space) 
+export BM_MYSQL_DBEXCLUDE=""
+
 ##############################################################
 # Backup method: PostgreSQL
 #############################################################

--- a/lib/backup-methods.sh
+++ b/lib/backup-methods.sh
@@ -992,6 +992,25 @@ function backup_method_mysql()
     base_command="$mysqldump --defaults-extra-file=$mysql_conffile $opt -u$BM_MYSQL_ADMINLOGIN -h$BM_MYSQL_HOST -P$BM_MYSQL_PORT $BM_MYSQL_EXTRA_OPTIONS"
     compress="$BM_MYSQL_FILETYPE"   
 
+    # get each DB name if backing up separately
+    if [ "$BM_MYSQL_DATABASES" = "__ALL__" ]; then
+        if [ "$BM_MYSQL_SEPARATELY" = "true" ]; then
+            if [[ ! -x $mysql ]]; then
+                error "Can´t find "$mysql" but this is needed when backing up databases separately."
+            fi
+
+            DBNAMES=$($mysql --defaults-extra-file=$mysql_conffile -u $BM_MYSQL_ADMINLOGIN -h $BM_MYSQL_HOST -P $BM_MYSQL_PORT -B -N -e "show databases" | sed 's/ /%/g')
+
+            # if DBs are excluded
+            for exclude in $BM_MYSQL_DBEXCLUDE
+            do
+                DBNAMES=$(echo $DBNAMES | sed "s/\b$exclude\b//g")
+            done
+
+            BM_MYSQL_DATABASES=$DBNAMES
+        fi
+    fi
+
     for database in $BM_MYSQL_DATABASES
     do
         if [[ "$database" = "__ALL__" ]]; then

--- a/lib/externals.sh
+++ b/lib/externals.sh
@@ -14,6 +14,7 @@ cdrecord=$(which cdrecord 2> /dev/null) || cdrecord=$(which wodim 2> /dev/null) 
 md5sum=$(which md5sum 2> /dev/null) || true
 bc=$(which bc 2> /dev/null) || true
 mysqldump=$(which mysqldump 2> /dev/null) || true
+mysql=$(which mysql 2> /dev/null) || true
 pgdump=$(which pg_dump 2>/dev/null) || true
 svnadmin=$(which svnadmin 2> /dev/null) || true
 logger=$(which logger 2> /dev/null) || true


### PR DESCRIPTION
See http://bugzilla.backup-manager.org/show_bug.cgi?id=193
This patch allows to make separate backups of all MySQL databases.
It´s also possible to exclude specific databases from the
backup.
