### PR TITLE
Report if backup-manager cannot access S3 store with IAM credentials

### DIFF
--- a/backup-manager-upload
+++ b/backup-manager-upload
@@ -886,6 +886,12 @@ sub send_files_with_s3($$$$$$)
 
 		my $response = $bucket_obj->list;
 
+		# check if S3 credentials are valid
+		if (! $response) {
+			print_error "Unable to access your S3 account. Check your AWS IAM credentials";
+			exit E_S3_FAILED;
+		}
+
 		if (not ( $response->{bucket} ) ) {
 			print_info "Bucket $bucket does not exist... creating";
 			$bucket_obj = $s3->add_bucket( { bucket => $bucket } );


### PR DESCRIPTION
If you type wrong credentials in the S3 Access key section, you don't get an error that the credentials are wrong. Instead, you receive an error saying that some other function is not working. This requires you to dive into the code in order to figure out why it does not work.
