### PR TITLE
Fix RedHat bug #1208596 (backup-manager package uses /share/locale/ while every other package use /usr/share/locale/)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright © 2005-2010 The Backup Manager Authors
+# Copyright Â© 2005-2010 The Backup Manager Authors
 # See the AUTHORS file for details.
 #
 # This program is free software; you can redistribute it and/or
@@ -90,7 +90,7 @@ install_doc:
 
 # The translation stuff
 install_po:
-	$(MAKE) -C po install
+	$(MAKE) -C po install DESTDIR=$(DESTDIR) PREFIX=$(PREFIX)
 
 # The backup-manager libraries
 install_lib:


### PR DESCRIPTION
Hi,

see https://bugzilla.redhat.com/show_bug.cgi?id=1208596
BM use /share directory for locale.

Thx