### PR TITLE
Upload: Add seperate TTL for S3 purge

### DIFF
--- a/backup-manager-upload
+++ b/backup-manager-upload
@@ -811,6 +811,10 @@ sub s3_clean_directory($)
 {
     my ($bucket) = @_;
     my $BM_ARCHIVE_TTL = $ENV{BM_ARCHIVE_TTL};
+    if (defined $ENV{BM_UPLOAD_S3_TTL} and
+        length ($ENV{BM_UPLOAD_S3_TTL})) {
+        $BM_ARCHIVE_TTL = $ENV{BM_UPLOAD_S3_TTL};
+    }
     return 0 unless defined $BM_ARCHIVE_TTL;
     my $date_to_remove = `date +%Y%m%d --date "$BM_ARCHIVE_TTL days ago"`;
     chomp $date_to_remove;

--- a/backup-manager.conf.tpl
+++ b/backup-manager.conf.tpl
@@ -454,6 +454,11 @@ export BM_UPLOAD_S3_SECRET_KEY=""
 # purge archives on remote hosts before uploading?
 export BM_UPLOAD_S3_PURGE="false"
 
+# You can specify a time to live for archives uploaded to S3
+# This can let you use different ttl's locally and remotely
+# By default, BM_ARCHIVE_TTL will be used.
+export BM_UPLOAD_S3_TTL=""
+
 ##############################################################
 # The RSYNC method
 #############################################################

--- a/doc/user-guide.sgml
+++ b/doc/user-guide.sgml
@@ -1410,6 +1410,17 @@ Example:
 export BM_UPLOAD_S3_PURGE="true"
 </example>
 
+<sect2 id="BM_UPLOAD_S3_TTL"><tt>BM_UPLOAD_S3_TTL</tt>
+<p>
+<em>Type: integer, default: $BM_ARCHIVE_TTL</em>
+<p>
+Using different <em>time to live</em> values for local and remote archives can
+be useful in certain situations.  For instance, it's possible to install &bmngr;
+locally, make it build archives, upload them to S3 and then purge them locally
+(but not on the remote host). Doing this is possible with setting a null value
+to the local TTL (BM_ARCHIVE_TTL) and a non-null value to BM_UPLOAD_S3_TTL.
+<p>
+
 <sect1 id="upload-rsync">RSYNC uploads
 <sect2 id="upload-rsync-desc">Description
 <p>

--- a/doc/user-guide.txt
+++ b/doc/user-guide.txt
@@ -1329,6 +1329,19 @@ export BM_POST_BACKUP_COMMAND="/usr/sbin/backup-manager --purge"
 
           export BM_UPLOAD_S3_PURGE="true"
 
+2.3.5.4. `BM_UPLOAD_S3_TTL'
+----------------------------
+
+     _Type: integer, default: $BM_ARCHIVE_TTL_
+
+     Using different _time to live_ values for local and remote archives can be
+     useful in certain situations.  For instance, it's possible to install
+     Backup Manager locally, make it build archives, upload them to S3 and then
+     purge them locally (but not on the remote host).  Doing this is possible
+     with setting a null value to the local TTL (BM_ARCHIVE_TTL) and a non-null
+     value to BM_UPLOAD_S3_TTL.
+
+
 2.3.7. RSYNC uploads
 --------------------
 


### PR DESCRIPTION
Add a seperate TTL for S3 (similar to BM_UPLOAD_FTP_TTL).

Signed-off-by: Nathaniel Clark <Nathaniel.Clark@misrule.us>