### PR TITLE
Enable SSH port definition support for rsync uploads

### DIFF
--- a/lib/upload-methods.sh
+++ b/lib/upload-methods.sh
@@ -192,7 +192,7 @@ function _exec_rsync_command()
            [[ -z "$BM_UPLOAD_SSH_KEY" ]]; then 
             error "Need a key to use rsync (set BM_UPLOAD_SSH_USER, BM_UPLOAD_SSH_KEY)."
         fi
-        ssh_option="ssh -l ${BM_UPLOAD_SSH_USER} -o BatchMode=yes -o ServerAliveInterval=60 -i ${BM_UPLOAD_SSH_KEY}"
+        ssh_option="ssh -l ${BM_UPLOAD_SSH_USER} -p ${BM_UPLOAD_SSH_PORT} -o BatchMode=yes -o ServerAliveInterval=60 -i ${BM_UPLOAD_SSH_KEY}"
         destination_option="${BM_UPLOAD_SSH_USER}@${host}:${destination_option}"
     fi
     


### PR DESCRIPTION
rsync uploads commonly use rsync over SSH. However, there is currently no way to specify the SSH port to contact.

This small modification makes BM_UPLOAD_SSH_PORT configuration setting usable with rsync too.