### PR TITLE
Fix pattern generation

### DIFF
--- a/lib/files.sh
+++ b/lib/files.sh
@@ -412,7 +412,7 @@ function purge_duplicate_archives()
         error "Unable to get date from file."
     fi
    
-    file_pattern=$(echo $file_to_create | sed -e "s/$date_of_file/\*/") || 
+    file_pattern=$(echo $file_to_create | sed -e "s/\\(.*\\)$date_of_file/\\1\*/") || 
         error "Unable to find the pattern of the file."
     
     # loop on each archive occurences (eg: archivename-*-filetype)


### PR DESCRIPTION
If the file path includes the current date, the pattern replaces the
date in the file path instead of the date of the backup date. This minor
change uses the greediness of the .* pattern to match on the last
occurrence of the date.