### PR TITLE
Update sanitize.sh

### DIFF
--- a/lib/sanitize.sh
+++ b/lib/sanitize.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env bash
-# Copyright © 2005-2016 The Backup Manager Authors
+# Copyright Â© 2005-2016 The Backup Manager Authors
 #
 # See the AUTHORS file for details.
 #
@@ -96,7 +96,8 @@ function replace_deprecated_booleans()
         value=$(echo "$line" | awk -F '=' '{print $2}')
         # Be sure to not treat BM_ARCHIVE_PREFIX as a deprecated boolean
         if [[ "$key" != "BM_ARCHIVE_PREFIX" ]]; then
-            if [[ -n "$key" ]]; then
+            klen=${#key}
+            if [[ $klen -gt 2 ]]; then
                 if [[ $(expr match "$key" BM_) -gt 0 ]]; then
                     if [[ "$value" = "yes" ]]; then
                         warning "Deprecated boolean, \$key is set to \"yes\", setting \"true\" instead."


### PR DESCRIPTION
Errors from expr sometimes occur if environment variables are parsed which contain parentheses. 

Instead of testing for non-zero length keys, the test for identifying keys to inspect can use the key length, only checking those that are at least 3 characters long (e.g. might start with BM_).

For example, this environment variable creates the issue:

```
BASH_FUNC_which%%=() {  ( alias;
 eval ${which_declare} ) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot "$@"
}

```
By checking that the parsed key length is greater than 2, unexpected parsing of the environment is less likely to create spurious error messages.